### PR TITLE
Update keepalived documentation to start when ready

### DIFF
--- a/swap-active-bond/keepalived-connected-ip-hook
+++ b/swap-active-bond/keepalived-connected-ip-hook
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+start () {
+    remove 2> /dev/null
+    systemctl start keepalived
+}
+stop () {
+    remove
+}
+remove () {
+    systemctl stop keepalived
+}
+
+# Avoid changing anything below here.
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    *)
+        echo "Usage: $0 {start|stop}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Starting the keepalived service too early can leave to unexpected
behaviour as a device encounters an error staste. Delaying the start of
keepalived until after the private connected IP has started greatly
mitigates this behaviour.